### PR TITLE
Remove density from PRODUCT_AAPT_CONFIG

### DIFF
--- a/bacon.mk
+++ b/bacon.mk
@@ -65,7 +65,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PACKAGES += camera.bacon
 
 # Device uses high-density artwork where available
-PRODUCT_AAPT_CONFIG := normal hdpi xhdpi xxhdpi
+PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi
 
 # call dalvik heap config


### PR DESCRIPTION
AAPT ignores densities in PRODUCT_AAPT_CONFIG.
The use of PRODUCT_AAPT_PREF_CONFIG for density is
encouraged, as AAPT is able to determine the fallback
density to use if a resource of the specified density
does not exist.

Change-Id: If2b43a44593bc234118045d03bd48cd9820dc05a
